### PR TITLE
add cfg-high/low and scheduler_hint outputs

### DIFF
--- a/nodes/ea_lightning_motion_bias.py
+++ b/nodes/ea_lightning_motion_bias.py
@@ -136,7 +136,7 @@ class EA_LightningMotionBias:
             },
         }
 
-    RETURN_TYPES = ("INT","INT","STRING","FLOAT","FLOAT","BOOLEAN","BOOLEAN","FLOAT","FLOAT","STRING")
+    RETURN_TYPES = ("INT","INT","STRING","FLOAT","FLOAT","BOOLEAN","BOOLEAN","FLOAT","FLOAT","*")
     RETURN_NAMES  = ("steps","split_step","sigmas_str","lightning_high_weight","lightning_low_weight","add_noise_high","add_noise_low","cfg_high","cfg_low","scheduler_hint")
     CATEGORY = "EA / Schedules"
     FUNCTION = "compute"


### PR DESCRIPTION
<img width="229" height="76" alt="image" src="https://github.com/user-attachments/assets/08823df0-fedf-43cd-a148-a4a1ee594ff4" />

Not sure why you wouldn't have output nodes for the cfg settings, though I can see why not for the scheduler... but someone may write a COMBO convert for that yet.

Well, this is close enough.  The easy-use "show any" will act as a proxy and it will talk to WanVideoWrapper to handle the scheduler.

<img width="443" height="126" alt="image" src="https://github.com/user-attachments/assets/e04d3f1d-db77-4a65-8d77-8f63b31a1fc1" />
